### PR TITLE
Bugfix in filter_genes

### DIFF
--- a/R/run_combat.R
+++ b/R/run_combat.R
@@ -253,10 +253,10 @@ filter_genes <- function(df,
         n_random <- n_genes - nrow(dff)
         random_genes <- df %>%
             dplyr::select(`_GENE`) %>%
-            dplyr::anti_join(genelist, by = `_GENE`) %>%
+            dplyr::anti_join(genelist, by = '_GENE') %>%
             dplyr::sample_n(n_random)
         genelist <- dplyr::bind_rows(genelist, random_genes)
-        dff <- df %>% dplyr::semi_join(genelist, by = `_GENE`)
+        dff <- df %>% dplyr::semi_join(genelist, by = '_GENE')
     }
     structure(dff, sampleinfo = attr(df, 'sampleinfo'))
 }


### PR DESCRIPTION
In 'by' parameters for dplyr joins within filter_genes function, I changed column names to be wrapped by quotes rather than backticks.

This makes the notation within the function consistent, fixes a bug I encountered, and seems to match dplyr's docs ("a _character vector_ of variables to join by").

I'm still quite new to R, so I may be misunderstanding the syntax. However, this change does fix the bug I was experiencing: `Error in common_by(by, x, y): object '_GENE' not found`